### PR TITLE
disable_remote option

### DIFF
--- a/lib/axr/helpers.rb
+++ b/lib/axr/helpers.rb
@@ -75,7 +75,7 @@ module AjaxfulRating # :nodoc:
     def ratings_for(*args)
       @axr_css ||= CSSBuilder.new
       options = args.extract_options!.symbolize_keys.slice(:small, :remote_options,
-        :wrap, :show_user_rating, :dimension, :force_static, :current_user)
+        :wrap, :show_user_rating, :dimension, :force_static, :current_user, :disable_remote)
       remote_options = options.delete(:remote_options) || {}
       rateable = args.shift
       user = args.shift || (respond_to?(:current_user) ? current_user : raise(NoUserSpecified))

--- a/lib/axr/stars_builder.rb
+++ b/lib/axr/stars_builder.rb
@@ -30,6 +30,7 @@ module AjaxfulRating # :nodoc:
         :wrap => true,
         :small => false,
         :show_user_rating => false,
+        :disable_remote => false,
         :force_static => false,
         :current_user => (@template.current_user if @template.respond_to?(:current_user))
       }.merge(options)
@@ -104,7 +105,12 @@ module AjaxfulRating # :nodoc:
         :url => "#{remote_options[:url]}",
         :with => "'#{query}'"
       }
-      @template.link_to_remote(value, remote_options.merge(config))
+      if options[:disable_remote]
+        config[:url] += "?" + query
+        @template.link_to(value, config[:url], config[:html])
+      else
+        @template.link_to_remote(value, remote_options.merge(config))
+      end
     end
     
     def wrapper_tag


### PR DESCRIPTION
Hi Edgarjs & Odorcicd,

I've added an option to the 'ratings_for' call so that the javascript that the onClick attribute can be disabled. 

I realise that this might be a strange behaviour for a project called ajaxful-rating however for the project I'm currently working on we have a lot of jquery integration client side and wanted to handle the post ourselves for a number of reasons.

Anyway thought it might be useful for other users.

It can be used as followed:

```
ratings_for movie, :disable_remote => true
```

Thanks for the great rating implementation, its really well done!
Alex
# Implementation
## Jquery

The following jquery can be used to handle the post:

```
$('ul.ajaxful-rating a').click(function() {
    var that = $(this);
    $.post(this.href, function(data, textStatus, XMLHttpRequest) {
        // ...
        that.blur();
        $('.show-value', that.parent().parent()).animate({width: data.percentage + "%"}, 'slow');
        // ...
    });
    return false;
});
```
## Controller

And I also created a controller method, which among other things does the following:

```
def rate
  @model = @model_class.find(params[:id])
  @model.rate(params[:stars], current_user)

  average = @model.rate_average(true)
  percentage = (average / @model.class.max_stars.to_f) * 100

  respond_to do |format|
    format.json { render :json => {:average => average, :percentage => percentage}.to_json }
  end
end
```
