### PR TITLE
Unnecessary queries for star_tag

### DIFF
--- a/lib/axr/stars_builder.rb
+++ b/lib/axr/stars_builder.rb
@@ -71,7 +71,7 @@ module AjaxfulRating # :nodoc:
     end
     
     def star_tag(value)
-      already_rated = rateable.rated_by?(user, options[:dimension]) if user
+      already_rated = rateable.rated_by?(user, options[:dimension]) if user && !rateable.axr_config(options[:dimension])[:allow_update]
       css_class = "stars-#{value}"
       @css_builder.rule(".ajaxful-rating .#{css_class}", {
         :width => "#{(value / rateable.class.max_stars.to_f) * 100}%",
@@ -79,7 +79,7 @@ module AjaxfulRating # :nodoc:
       })
 
       @template.content_tag(:li) do
-        if !options[:force_static] && (user && options[:current_user] == user && (!already_rated || rateable.axr_config(options[:dimension])[:allow_update]))
+        if !options[:force_static] && !already_rated && user && options[:current_user] == user
           link_star_tag(value, css_class)
         else
           @template.content_tag(:span, show_value, :class => css_class, :title => i18n(:current))


### PR DESCRIPTION
When a rateable object has :allow_update set to true, the star_tag method doesn't need to check to see if the object has already been rated.

I was seeing a lot of extraneous database calls when I was logged in, especially on my rateable#index page:

```
  Rate Load (0.6ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 756 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 756 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 756 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 756 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 756 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.6ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 755 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 755 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 755 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 755 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 755 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.4ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 752 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 752 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 752 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 752 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 752 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.3ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 762 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 762 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 762 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 762 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 762 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT    
  Rate Load (0.4ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 754 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 754 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 754 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 754 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 754 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.4ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 753 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 753 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 753 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 753 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 753 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.6ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 763 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 763 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 763 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 763 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 763 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  Rate Load (0.4ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 751 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 751 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 751 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 751 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1
  CACHE (0.0ms)  SELECT "rates".* FROM "rates" WHERE "rates"."rateable_id" = 751 AND "rates"."rateable_type" = 'Song' AND "rates"."dimension" = 'enjoyment' AND "rates"."rater_id" = 1 LIMIT 1

```

These calls totally make sense when we don't want users to update their ratings, but otherwise they're unnecessary.

Problem fixed by moving the :allow_update config check up.
