### PR TITLE
Rails3 rename rate model

### DIFF
--- a/lib/axr/model.rb
+++ b/lib/axr/model.rb
@@ -18,7 +18,8 @@ module AjaxfulRating # :nodoc:
     #     ajaxful_rateable :stars => 10, :cache_column => :custom_column
     #   end
     def ajaxful_rateable(options = {})
-      has_many :rates_without_dimension, :as => :rateable, options.merge(:class_name => 'Rate'), :dependent => :destroy, :conditions => {:dimension => nil}
+      options[:class_name]||='Rate'
+      has_many :rates_without_dimension, :as => :rateable, :class_name=>options[:class_name], :dependent => :destroy, :conditions => {:dimension => nil}
       has_many :raters_without_dimension, :through => :rates_without_dimension, :source => :rater
 
       class << self


### PR DESCRIPTION
added support for being able to rename :class_name in ajaxful_rateable on rails 3 branch; fixed .merge within a {} error
