### PR TITLE
added support for being able to rename :class_name in ajaxful_rateable

### DIFF
--- a/lib/axr/model.rb
+++ b/lib/axr/model.rb
@@ -20,8 +20,8 @@ module AjaxfulRating # :nodoc:
     #     ajaxful_rateable :stars => 10, :cache_column => :custom_column
     #   end
     def ajaxful_rateable(options = {})
-      has_many :rates_without_dimension, :as => :rateable, options.merge(:class_name => 'Rate'),
-        :dependent => :destroy, :conditions => {:dimension => nil}
+      options[:class_name]||='Rate'
+      has_many :rates_without_dimension, :as => :rateable, :class_name=>options[:class_name], :dependent => :destroy, :conditions => {:dimension => nil}
       has_many :raters_without_dimension, :through => :rates_without_dimension, :source => :rater
 
       options[:dimensions].each do |dimension|


### PR DESCRIPTION
fixed that same .merge within {} syntax error for the master branch
