### PR TITLE
fix join on association

### DIFF
--- a/lib/axr/model.rb
+++ b/lib/axr/model.rb
@@ -25,9 +25,9 @@ module AjaxfulRating # :nodoc:
       has_many :raters_without_dimension, :through => :rates_without_dimension, :source => :rater
 
       options[:dimensions].each do |dimension|
-        has_many "#{dimension}_rates", :dependent => :destroy,
+        has_many :"#{dimension}_rates", :dependent => :destroy,
           :conditions => {:dimension => dimension.to_s}, :class_name => 'Rate', :as => :rateable
-        has_many "#{dimension}_raters", :through => "#{dimension}_rates", :source => :rater
+        has_many :"#{dimension}_raters", :through => "#{dimension}_rates", :source => :rater
       end if options[:dimensions].is_a?(Array)
 
       class << self


### PR DESCRIPTION
The associations #{dimension}_rates and #{dimension}_raters need to be named with symbols instead of strings. If not, joining on them won't work (e.g. Model.joins(:dimension_rates) or Model.joins("dimension_rates") won't work).
