### PR TITLE
Rails3 fix dimension ratings

### DIFF
--- a/lib/axr/model.rb
+++ b/lib/axr/model.rb
@@ -78,7 +78,7 @@ module AjaxfulRating # :nodoc:
     #     # some page update here ...
     #   end
     def rate(stars, user, dimension = nil)
-      return false if (stars.to_i > self.class.max_stars) || (stars.to_i < 1)
+      return false if (stars.to_i > self.class.max_stars(dimension)) || (stars.to_i < 1)
       raise Errors::AlreadyRatedError if (!self.class.axr_config(dimension)[:allow_update] && rated_by?(user, dimension))
 
       rate = if self.class.axr_config(dimension)[:allow_update] && rated_by?(user, dimension)

--- a/lib/axr/model.rb
+++ b/lib/axr/model.rb
@@ -86,6 +86,7 @@ module AjaxfulRating # :nodoc:
       else
         rates(dimension).build.tap do |r|
           r.rater = user
+          r.dimension = dimension
         end
       end
       rate.stars = stars
@@ -128,7 +129,10 @@ module AjaxfulRating # :nodoc:
 
     # Finds the rate made by the user if he/she has already voted.
     def rate_by(user, dimension = nil)
-      rates(dimension).find_by_rater_id(user.id)
+      rates(dimension).
+        where(:dimension => dimension).
+        where(:rater_id => user.id).
+        first
     end
 
     # Return true if the user has rated the object, otherwise false


### PR DESCRIPTION
Using this gem without any dimensions would work, but as our project used dimensions, it broke pretty badly when we switched from Rails 2.3.x to Rails 3.2.13.

Fixed Rails bug compatibility (ha) and found a bug related to dimension max stars. Now dimensions work again!

Hope this helps :zap:
